### PR TITLE
Efl.Ui.Progressbar: Add explicit display control of progress label

### DIFF
--- a/src/bin/elementary/test_ui_progressbar.c
+++ b/src/bin/elementary/test_ui_progressbar.c
@@ -9,6 +9,10 @@ typedef struct _pbdata
    Eo *win;
    Eo *pb1;
    Eo *pb2;
+   Eo *pb3;
+   Eo *pb4;
+   Eo *pb5;
+   Eo *check;
    Eo *btn_start;
    Eo *btn_stop;
    Eo *btn_reset;
@@ -45,6 +49,9 @@ _pb_timer_cb(void *d)
      {
         progress_val += 1;
         efl_ui_range_value_set(pd->pb2, progress_val);
+        efl_ui_range_value_set(pd->pb3, progress_val);
+        efl_ui_range_value_set(pd->pb4, progress_val);
+        efl_ui_range_value_set(pd->pb5, progress_val);
      }
 
    if (!_set_progress_val(pd->pb1, 0.5))
@@ -97,6 +104,9 @@ _reset_btn_clicked_cb(void *d, const Efl_Event *ev EINA_UNUSED)
 
    efl_ui_range_value_set(pd->pb1, 0.0);
    efl_ui_range_value_set(pd->pb2, 0.0);
+   efl_ui_range_value_set(pd->pb3, 0.0);
+   efl_ui_range_value_set(pd->pb4, 0.0);
+   efl_ui_range_value_set(pd->pb5, 0.0);
 }
 
 static void
@@ -107,6 +117,28 @@ _win_delete_req_cb(void *d, const Efl_Event *ev EINA_UNUSED)
    if (pd->timer) ecore_timer_del(pd->timer);
    efl_unref(pd->win);
    free(pd);
+}
+
+static void
+_custom_format_cb(void *data EINA_UNUSED, Eina_Strbuf *str, const Eina_Value value)
+{
+   double v;
+   eina_value_get(&value, &v);
+   if (v < 25.f) eina_strbuf_append_printf(str, "Starting up...");
+   else if (v < 50.f) eina_strbuf_append_printf(str, "Working...");
+   else if (v < 75.f) eina_strbuf_append_printf(str, "Getting there...");
+   else if (v < 100.f) eina_strbuf_append_printf(str, "Almost done...");
+   else eina_strbuf_append_printf(str, "Done!");
+}
+
+static void
+_toggle_progress_label(void *data, const Efl_Event *ev)
+{
+   Efl_Ui_Check *check = ev->object;
+   Efl_Ui_Progressbar *pb3 = data;
+   Eina_Bool state = efl_ui_check_selected_get(check);
+
+   efl_ui_progressbar_show_progress_label_set(pb3, state);
 }
 
 void
@@ -151,6 +183,37 @@ test_ui_progressbar(void *data EINA_UNUSED, Eo *obj EINA_UNUSED, void *event_inf
                      efl_gfx_hint_size_min_set(efl_added, EINA_SIZE2D(250, 20)),
                      efl_ui_range_limits_set(efl_added, 10, 100),
                      efl_ui_range_value_set(efl_added, 10)
+                    );
+
+   pd->pb3 = efl_add(EFL_UI_PROGRESSBAR_CLASS, bx,
+                     efl_pack(bx, efl_added),
+                     efl_text_set(efl_added, "Toggle progress label"),
+                     efl_ui_range_limits_set(efl_added, 0, 100),
+                     efl_ui_progressbar_show_progress_label_set(efl_added, EINA_FALSE),
+                     efl_gfx_hint_size_min_set(efl_added, EINA_SIZE2D(250, 20))
+                    );
+   pd->check = efl_add(EFL_UI_CHECK_CLASS, bx,
+                       efl_pack(bx, efl_added),
+                       efl_event_callback_add(efl_added, EFL_UI_CHECK_EVENT_SELECTED_CHANGED,
+                                              _toggle_progress_label, pd->pb3),
+                       efl_gfx_hint_size_min_set(efl_added, EINA_SIZE2D(250, 20))
+                      );
+   efl_text_set(pd->check, "Show progress label of above progressbar"),
+
+   pd->pb4 = efl_add(EFL_UI_PROGRESSBAR_CLASS, bx,
+                     efl_pack(bx, efl_added),
+                     efl_text_set(efl_added, "Custom string"),
+                     efl_ui_range_limits_set(efl_added, 0, 100),
+                     efl_ui_format_string_set(efl_added, "%d rabbits"),
+                     efl_gfx_hint_size_min_set(efl_added, EINA_SIZE2D(250, 20))
+                    );
+
+   pd->pb5 = efl_add(EFL_UI_PROGRESSBAR_CLASS, bx,
+                     efl_pack(bx, efl_added),
+                     efl_text_set(efl_added, "Custom func"),
+                     efl_ui_range_limits_set(efl_added, 0, 100),
+                     efl_ui_format_cb_set(efl_added, NULL, _custom_format_cb, NULL),
+                     efl_gfx_hint_size_min_set(efl_added, EINA_SIZE2D(250, 20))
                     );
 
    btbx = efl_add(EFL_UI_BOX_CLASS, bx,

--- a/src/lib/elementary/efl_ui_progressbar.c
+++ b/src/lib/elementary/efl_ui_progressbar.c
@@ -73,7 +73,7 @@ _units_set(Evas_Object *obj)
 {
    EFL_UI_PROGRESSBAR_DATA_GET(obj, sd);
 
-   if (sd->format_cb)
+   if (sd->show_progress_label && sd->format_cb)
      {
         Eina_Value val;
 
@@ -240,7 +240,7 @@ _efl_ui_progressbar_efl_ui_widget_theme_apply(Eo *obj, Efl_Ui_Progressbar_Data *
         if (sd->pulse_state)
           elm_layout_signal_emit(obj, "elm,state,pulse,start", "elm");
 
-        if (sd->format_cb && (!sd->pulse))
+        if (sd->show_progress_label && (!sd->pulse))
           elm_layout_signal_emit(obj, "elm,state,units,visible", "elm");
      }
    else
@@ -253,7 +253,7 @@ _efl_ui_progressbar_efl_ui_widget_theme_apply(Eo *obj, Efl_Ui_Progressbar_Data *
         if (sd->pulse_state)
           elm_layout_signal_emit(obj, "efl,state,pulse,start", "efl");
 
-        if (sd->format_cb && (!sd->pulse))
+        if (sd->show_progress_label && (!sd->pulse))
           elm_layout_signal_emit(obj, "efl,state,units,visible", "efl");
      }
    sd->has_status_text_part = edje_object_part_exists(obj, statuspart[elm_widget_is_legacy(obj)]);
@@ -415,6 +415,7 @@ _efl_ui_progressbar_efl_object_constructor(Eo *obj, Efl_Ui_Progressbar_Data *_pd
    evas_object_smart_callbacks_descriptions_set(obj, _smart_callbacks);
    efl_access_object_role_set(obj, EFL_ACCESS_ROLE_PROGRESS_BAR);
    efl_ui_range_limits_set(obj, 0.0, 1.0);
+   efl_ui_progressbar_show_progress_label_set(obj, EINA_TRUE);
    return obj;
 }
 
@@ -747,6 +748,29 @@ _efl_ui_progressbar_part_efl_ui_range_display_range_limits_get(const Eo *obj, vo
              break;
           }
      }
+}
+
+EOLIAN static void
+_efl_ui_progressbar_show_progress_label_set(Eo *obj EINA_UNUSED, Efl_Ui_Progressbar_Data *pd, Eina_Bool show)
+{
+   ELM_WIDGET_DATA_GET_OR_RETURN(obj, wd);
+   char signal_name[32];
+   const char *ns = elm_widget_is_legacy(obj) ? "elm" : "efl";
+
+   pd->show_progress_label = show;
+
+   snprintf(signal_name, sizeof(signal_name), "%s,state,units,%s", ns,
+            show ? "visible" : "hidden");
+   elm_layout_signal_emit(obj, signal_name, ns);
+   edje_object_message_signal_process(wd->resize_obj);
+   _units_set(obj);
+   elm_layout_sizing_eval(obj);
+}
+
+EOLIAN static Eina_Bool
+_efl_ui_progressbar_show_progress_label_get(const Eo *obj EINA_UNUSED, Efl_Ui_Progressbar_Data *pd)
+{
+   return pd->show_progress_label;
 }
 
 #include "efl_ui_progressbar_part.eo.c"

--- a/src/lib/elementary/efl_ui_progressbar.eo
+++ b/src/lib/elementary/efl_ui_progressbar.eo
@@ -41,6 +41,16 @@ class @beta Efl.Ui.Progressbar extends Efl.Ui.Layout_Base implements Efl.Ui.Rang
            state: bool; [[$true, to start the pulsing animation, $false to stop it]]
          }
       }
+      @property show_progress_label {
+         [[Whether a textual progress label is shown alongside the progressbar to give an exact
+           numerical indication of the current progress.
+
+           Not to be confused with the widget label set through @Efl.Text.text.
+         ]]
+         values {
+           show: bool; [[$true to show the progress label.]]
+         }
+      }
    }
    implements {
       Efl.Object.constructor;

--- a/src/lib/elementary/efl_ui_progressbar_private.h
+++ b/src/lib/elementary/efl_ui_progressbar_private.h
@@ -51,6 +51,7 @@ struct _Efl_Ui_Progressbar_Data
    Eina_Bool             is_legacy_format_cb : 1;
    Eina_Bool             has_status_text_part : 1;
    Eina_Bool             has_cur_progressbar_part : 1;
+   Eina_Bool             show_progress_label : 1; /**< Show a progress text label besides the progressbar */
 };
 
 struct _Efl_Ui_Progress_Status

--- a/src/tests/elementary/efl_ui_suite.c
+++ b/src/tests/elementary/efl_ui_suite.c
@@ -26,6 +26,7 @@ static const Efl_Test_Case etc[] = {
   { "efl_ui_widget", efl_ui_test_widget },
   { "efl_ui_active_view", efl_ui_test_active_view},
   { "efl_ui_check", efl_ui_test_check },
+  { "efl_ui_progressbar", efl_ui_test_progressbar },
   { "efl_ui_radio_group", efl_ui_test_radio_group },
   { "efl_ui_win", efl_ui_test_win },
   { NULL, NULL }

--- a/src/tests/elementary/efl_ui_suite.h
+++ b/src/tests/elementary/efl_ui_suite.h
@@ -37,6 +37,7 @@ void efl_ui_model(TCase *tc);
 void efl_ui_test_widget(TCase *tc);
 void efl_ui_test_active_view(TCase *tc);
 void efl_ui_test_check(TCase *tc);
+void efl_ui_test_progressbar(TCase *tc);
 void efl_ui_test_radio_group(TCase *tc);
 void efl_ui_test_win(TCase *tc);
 

--- a/src/tests/elementary/efl_ui_test_progressbar.c
+++ b/src/tests/elementary/efl_ui_test_progressbar.c
@@ -1,0 +1,39 @@
+#ifdef HAVE_CONFIG_H
+# include "elementary_config.h"
+#endif
+
+#include <Efl_Ui.h>
+#include "efl_ui_suite.h"
+
+static Eo *win, *pb;
+
+static void
+check_setup()
+{
+   win = win_add();
+
+   pb = efl_add(EFL_UI_PROGRESSBAR_CLASS, win);
+}
+
+EFL_START_TEST(pb_text)
+{
+   efl_text_set(pb, "Test the Rest");
+   ck_assert_str_eq(efl_text_get(pb), "Test the Rest");
+}
+EFL_END_TEST
+
+EFL_START_TEST(pb_progress_label)
+{
+   efl_ui_progressbar_show_progress_label_set(pb, EINA_TRUE);
+   ck_assert_int_eq(efl_ui_progressbar_show_progress_label_get(pb), EINA_TRUE);
+   efl_ui_progressbar_show_progress_label_set(pb, EINA_FALSE);
+   ck_assert_int_eq(efl_ui_progressbar_show_progress_label_get(pb), EINA_FALSE);
+}
+EFL_END_TEST
+
+void efl_ui_test_progressbar(TCase *tc)
+{
+   tcase_add_checked_fixture(tc, check_setup, NULL);
+   tcase_add_test(tc, pb_text);
+   tcase_add_test(tc, pb_progress_label);
+}

--- a/src/tests/elementary/meson.build
+++ b/src/tests/elementary/meson.build
@@ -142,6 +142,7 @@ efl_ui_suite_src = [
   'efl_ui_test_active_view.c',
   'efl_ui_test_check.c',
   'efl_ui_test_radio_group.c',
+  'efl_ui_test_progressbar.c',
 ]
 
 efl_ui_suite = executable('efl_ui_suite',


### PR DESCRIPTION
Summary:
Add a property (show_progress_label) to allow controlling whether the progress
label displaying the exact progress is shown or not.
This was possible in Legacy but the functionality was lost in Unified.

Updated elementary_test to showcase this property, and also the other label
formatting options, which where not tested anywhere.

Added a simple progressbar unit test. It only checks that retrieved value is the
same as the set value, so it is more of a placeholder for future tests.

**This is needed by a future patch which will introduce more formatting options that clash with the current implementation.**
The presence of a formatting function was used to decide if the progress label was shown or not. This explicit property simplifies things.

Test Plan:
Everything builds and passes tests.
`elementary_test -to Efl.Ui.Progressbar` should show a few more bars with different formatting labels, and a checkbox to toggle rendering of one of them.

Reviewers: bu5hm4n, zmike, cedric

Subscribers: #reviewers, #committers

Tags: #efl

Differential Revision: https://phab.enlightenment.org/D9202