### PR TITLE
elm_check/radio: restore legacy behavior

### DIFF
--- a/src/lib/elementary/efl_ui_check.c
+++ b/src/lib/elementary/efl_ui_check.c
@@ -96,6 +96,8 @@ _activate(Evas_Object *obj)
    // "elm,state,check,on" or "elm,state,check,off" for legacy
    // "efl,state,check,on" or "efl,state,check,off" for eo-api
    efl_ui_check_selected_set(obj, !efl_ui_check_selected_get(obj));
+   if (elm_widget_is_legacy(obj))
+     evas_object_smart_callback_call(obj, "changed", NULL);
 
    if (_elm_config->atspi_mode)
      efl_access_state_changed_signal_emit(obj,
@@ -291,9 +293,7 @@ _efl_ui_check_selected_set(Eo *obj, Efl_Ui_Check_Data *pd, Eina_Bool value)
 
    pd->selected = value;
 
-   if (elm_widget_is_legacy(obj))
-     evas_object_smart_callback_call(obj, "changed", NULL);
-   else
+   if (!elm_widget_is_legacy(obj))
      efl_event_callback_call(obj, EFL_UI_CHECK_EVENT_SELECTED_CHANGED, &pd->selected);
 }
 

--- a/src/lib/elementary/efl_ui_radio.c
+++ b/src/lib/elementary/efl_ui_radio.c
@@ -139,6 +139,7 @@ _activate(Evas_Object *obj)
              if (_elm_config->access_mode)
                _elm_access_say(E_("State: On"));
          }
+        evas_object_smart_callback_call(obj, "changed", NULL);
      }
    else
      {

--- a/src/tests/elementary/elm_test_radio.c
+++ b/src/tests/elementary/elm_test_radio.c
@@ -41,8 +41,65 @@ EFL_START_TEST(elm_atspi_role_get)
 }
 EFL_END_TEST
 
+static unsigned int radio_change_count = 0;
+
+static void
+_rdg_changed_cb()
+{
+   radio_change_count++;
+   ecore_main_loop_quit();
+}
+
+EFL_START_TEST(elm_test_radio_selection)
+{
+   radio_change_count = 0;
+   Evas_Object *rd, *rdg;
+   Evas_Object *win = win_add(NULL, "radio", ELM_WIN_BASIC);
+   evas_object_resize(win, 100, 100);
+
+   // radio 1
+   rd = elm_radio_add(win);
+   evas_object_resize(rd, 100, 100);
+
+   // rdg radio group
+   rdg = rd;
+   evas_object_smart_callback_add(rdg, "changed", _rdg_changed_cb, NULL);
+
+   elm_radio_state_value_set(rd, 1);
+   elm_object_text_set(rd, "Radio Group Test #1");
+   evas_object_show(rd);
+
+
+   // radio 2
+   rd = elm_radio_add(win);
+   evas_object_smart_callback_add(rd, "changed", _rdg_changed_cb, NULL);
+   evas_object_resize(rd, 100, 100);
+   elm_radio_state_value_set(rd, 2);
+   elm_object_text_set(rd, "Radio Group Test #2");
+   elm_radio_group_add(rd, rdg);
+   evas_object_show(rd);
+   evas_object_show(win);
+
+   elm_layout_signal_emit(rdg, "elm,action,radio,toggle", "elm");
+   ecore_main_loop_begin();
+   ck_assert_int_eq(elm_radio_value_get(rdg), 1);
+   ck_assert_int_eq(radio_change_count, 1);
+
+   elm_layout_signal_emit(rd, "elm,action,radio,toggle", "elm");
+   ecore_main_loop_begin();
+   ck_assert_int_eq(elm_radio_value_get(rdg), 2);
+   ck_assert_int_eq(radio_change_count, 2);
+
+   elm_layout_signal_emit(rdg, "elm,action,radio,toggle", "elm");
+   ecore_main_loop_begin();
+   ck_assert_int_eq(elm_radio_value_get(rdg), 1);
+   ck_assert_int_eq(radio_change_count, 3);
+}
+EFL_END_TEST
+
 void elm_test_radio(TCase *tc)
 {
    tcase_add_test(tc, elm_radio_legacy_type_check);
    tcase_add_test(tc, elm_atspi_role_get);
+   tcase_add_test(tc, elm_test_radio_selection);
 }

--- a/src/tests/elementary/elm_test_radio.c
+++ b/src/tests/elementary/elm_test_radio.c
@@ -97,9 +97,46 @@ EFL_START_TEST(elm_test_radio_selection)
 }
 EFL_END_TEST
 
+EFL_START_TEST(elm_test_radio_callback)
+{
+   radio_change_count = 0;
+   Evas_Object *rd, *rdg;
+   Evas_Object *win = win_add(NULL, "radio", ELM_WIN_BASIC);
+   evas_object_resize(win, 100, 100);
+
+   // radio 1
+   rd = elm_radio_add(win);
+   evas_object_resize(rd, 100, 100);
+
+   // rdg radio group
+   rdg = rd;
+   evas_object_smart_callback_add(rdg, "changed", _rdg_changed_cb, NULL);
+
+   elm_radio_state_value_set(rd, 1);
+   elm_object_text_set(rd, "Radio Group Test #1");
+   evas_object_show(rd);
+
+
+   // radio 2
+   rd = elm_radio_add(win);
+   evas_object_resize(rd, 100, 100);
+   elm_radio_state_value_set(rd, 2);
+   elm_object_text_set(rd, "Radio Group Test #2");
+   elm_radio_group_add(rd, rdg);
+   evas_object_show(rd);
+   evas_object_show(win);
+
+   elm_radio_value_set(rdg, 2);
+   elm_radio_value_set(rdg, 1);
+   elm_radio_value_set(rdg, 2);
+   ck_assert_int_eq(radio_change_count, 0);
+}
+EFL_END_TEST
+
 void elm_test_radio(TCase *tc)
 {
    tcase_add_test(tc, elm_radio_legacy_type_check);
    tcase_add_test(tc, elm_atspi_role_get);
    tcase_add_test(tc, elm_test_radio_selection);
+   tcase_add_test(tc, elm_test_radio_callback);
 }


### PR DESCRIPTION
This restores the behavior that "changed" events are only emitted due to user interaction, not due to API usage. The unified API is not impacted by this.