### PR TITLE
efl_ui_spin: add overall tests for stabilization of API

### DIFF
--- a/src/lib/elementary/Efl_Ui.h
+++ b/src/lib/elementary/Efl_Ui.h
@@ -247,6 +247,7 @@ typedef Eo Efl_Ui_Active_View_Indicator;
 # include <efl_ui_clickable.eo.h>
 # include <efl_ui_clickable_util.eo.h>
 # include <efl_ui_format.eo.h>
+# include <efl_ui_spin.eo.h>
 
 /**
  * Initialize Elementary

--- a/src/lib/elementary/efl_ui_progressbar.c
+++ b/src/lib/elementary/efl_ui_progressbar.c
@@ -593,6 +593,17 @@ _progressbar_part_value_get(Efl_Ui_Progressbar_Data *sd, const char* part)
 EOLIAN static void
 _efl_ui_progressbar_efl_ui_range_display_range_value_set(Eo *obj, Efl_Ui_Progressbar_Data *sd, double val)
 {
+   if (val < sd->val_min)
+     {
+        ERR("Error, value is lower than minimum");
+        return;
+     }
+
+   if (val > sd->val_max)
+     {
+        ERR("Error, value is bigger than maximum");
+        return;
+     }
    if (EINA_DBL_EQ(sd->val, val)) return;
 
    if (elm_widget_is_legacy(obj))
@@ -644,6 +655,16 @@ _efl_ui_progressbar_pulse_get(const Eo *obj EINA_UNUSED, Efl_Ui_Progressbar_Data
 EOLIAN static void
 _efl_ui_progressbar_efl_ui_range_display_range_limits_set(Eo *obj, Efl_Ui_Progressbar_Data *sd, double min, double max)
 {
+   if (max < min)
+     {
+        ERR("Wrong params. min(%lf) is bigger than max(%lf).", min, max);
+        return;
+     }
+   if (EINA_DBL_EQ(max, min))
+     {
+        ERR("min and max must have a different value");
+        return;
+     }
   if (elm_widget_is_legacy(obj))
     _progress_part_min_max_set(obj, sd, "elm.cur.progressbar", min, max);
   else

--- a/src/lib/elementary/efl_ui_slider.c
+++ b/src/lib/elementary/efl_ui_slider.c
@@ -784,10 +784,13 @@ _efl_ui_slider_efl_ui_range_interactive_range_step_get(const Eo *obj EINA_UNUSED
 EOLIAN static void
 _efl_ui_slider_efl_ui_range_interactive_range_step_set(Eo *obj EINA_UNUSED, Efl_Ui_Slider_Data *sd, double step)
 {
-   if (sd->step == step) return;
+   if (step <= 0)
+     {
+        ERR("Wrong param. The step(%lf) should be bigger than 0.0", step);
+        return;
+     }
 
-   if (step < 0.0) step = 0.0;
-   else if (step > 1.0) step = 1.0;
+   if (sd->step == step) return;
 
    sd->step = step;
 }

--- a/src/lib/elementary/efl_ui_slider.c
+++ b/src/lib/elementary/efl_ui_slider.c
@@ -719,7 +719,17 @@ _efl_ui_slider_efl_ui_layout_orientable_orientation_get(const Eo *obj EINA_UNUSE
 EOLIAN static void
 _efl_ui_slider_efl_ui_range_display_range_limits_set(Eo *obj, Efl_Ui_Slider_Data *sd, double min, double max)
 {
-   if ((sd->val_min == min) && (sd->val_max == max)) return;
+   if (max < min)
+     {
+        ERR("Wrong params. min(%lf) is bigger than max(%lf).", min, max);
+        return;
+     }
+   if (EINA_DBL_EQ(max, min))
+     {
+        ERR("min and max must have a different value");
+        return;
+     }
+   if ((EINA_DBL_EQ(sd->val_min, min)) && (EINA_DBL_EQ(sd->val_max, max))) return;
    sd->val_min = min;
    sd->val_max = max;
    if (sd->val < sd->val_min) sd->val = sd->val_min;
@@ -738,7 +748,19 @@ _efl_ui_slider_efl_ui_range_display_range_limits_get(const Eo *obj EINA_UNUSED, 
 EOLIAN static void
 _efl_ui_slider_efl_ui_range_display_range_value_set(Eo *obj, Efl_Ui_Slider_Data *sd, double val)
 {
-   if (sd->val == val) return;
+   if (val < sd->val_min)
+     {
+        ERR("Error, value is lower than minimum");
+        return;
+     }
+
+   if (val > sd->val_max)
+     {
+        ERR("Error, value is bigger than maximum");
+        return;
+     }
+
+   if (EINA_DBL_EQ(val, sd->val)) return;
    sd->val = val;
 
    if (sd->val < sd->val_min) sd->val = sd->val_min;

--- a/src/lib/elementary/efl_ui_spin.c
+++ b/src/lib/elementary/efl_ui_spin.c
@@ -108,10 +108,13 @@ _efl_ui_spin_efl_ui_range_display_range_limits_set(Eo *obj, Efl_Ui_Spin_Data *sd
 {
    if (max < min)
      {
-        ERR("Wrong params. min(%lf) is bigger than max(%lf). It will swaped.", min, max);
-        double t = min;
-        min = max;
-        max = t;
+        ERR("Wrong params. min(%lf) is bigger than max(%lf).", min, max);
+        return;
+     }
+   if (EINA_DBL_EQ(max, min))
+     {
+        ERR("min and max must have a different value");
+        return;
      }
    if ((EINA_DBL_EQ(sd->val_min, min)) && (EINA_DBL_EQ(sd->val_max, max))) return;
 
@@ -153,9 +156,16 @@ EOLIAN static void
 _efl_ui_spin_efl_ui_range_display_range_value_set(Eo *obj, Efl_Ui_Spin_Data *sd, double val)
 {
    if (val < sd->val_min)
-     val = sd->val_min;
-   else if (val > sd->val_max)
-     val = sd->val_max;
+     {
+        ERR("Error, value is lower than minimum");
+        return;
+     }
+
+   if (val > sd->val_max)
+     {
+        ERR("Error, value is bigger than maximum");
+        return;
+     }
 
    if (EINA_DBL_EQ(val, sd->val)) return;
 

--- a/src/lib/elementary/efl_ui_spin_button.c
+++ b/src/lib/elementary/efl_ui_spin_button.c
@@ -168,7 +168,7 @@ static void
 _entry_value_apply(Evas_Object *obj)
 {
    const char *str;
-   double val;
+   double val, val_min, val_max;
    char *end;
 
    Efl_Ui_Spin_Button_Data *sd = efl_data_scope_get(obj, MY_CLASS);
@@ -184,6 +184,8 @@ _entry_value_apply(Evas_Object *obj)
 
    val = strtod(str, &end);
    if (((*end != '\0') && (!isspace(*end))) || (fabs(val - pd->val) < DBL_EPSILON)) return;
+   efl_ui_range_limits_get(obj, &val_min, &val_max);
+   val = MIN(val_max, MAX(val_min, val));
    efl_ui_range_value_set(obj, val);
 
    efl_event_callback_call(obj, EFL_UI_SPIN_EVENT_CHANGED, NULL);
@@ -406,7 +408,9 @@ _spin_value(void *data)
    Efl_Ui_Spin_Button_Data *sd = efl_data_scope_get(data, MY_CLASS);
    Efl_Ui_Spin_Data *pd = efl_data_scope_get(data, EFL_UI_SPIN_CLASS);
 
-   if (_value_set(data, pd->val + (sd->inc_val ? pd->step : -pd->step)))
+   int absolut_value = pd->val + (sd->inc_val ? pd->step : -pd->step);
+
+   if (_value_set(data, MIN(MAX(absolut_value, pd->val_min), pd->val_max)))
      _label_write(data);
 
    return ECORE_CALLBACK_RENEW;

--- a/src/tests/elementary/efl_ui_suite.c
+++ b/src/tests/elementary/efl_ui_suite.c
@@ -29,6 +29,7 @@ static const Efl_Test_Case etc[] = {
   { "efl_ui_progressbar", efl_ui_test_progressbar },
   { "efl_ui_radio_group", efl_ui_test_radio_group },
   { "efl_ui_win", efl_ui_test_win },
+  { "efl_ui_spin", efl_ui_test_spin },
   { NULL, NULL }
 };
 

--- a/src/tests/elementary/efl_ui_suite.h
+++ b/src/tests/elementary/efl_ui_suite.h
@@ -40,6 +40,7 @@ void efl_ui_test_check(TCase *tc);
 void efl_ui_test_progressbar(TCase *tc);
 void efl_ui_test_radio_group(TCase *tc);
 void efl_ui_test_win(TCase *tc);
+void efl_ui_test_spin(TCase *tc);
 
 void loop_timer_interval_set(Eo *obj, double in);
 

--- a/src/tests/elementary/efl_ui_test_spin.c
+++ b/src/tests/elementary/efl_ui_test_spin.c
@@ -1,0 +1,86 @@
+#ifdef HAVE_CONFIG_H
+# include "elementary_config.h"
+#endif
+
+#include <Efl_Ui.h>
+#include "efl_ui_suite.h"
+
+static Eo *win, *spin;
+
+static void
+spin_setup()
+{
+   win = win_add();
+
+   spin = efl_add(EFL_UI_SPIN_CLASS, win);
+   efl_content_set(win, spin);
+}
+
+static void
+_set_flag(void *data, const Efl_Event *ev)
+{
+   Eina_Bool *b = data;
+
+   *b = EINA_TRUE;
+   ck_assert_ptr_eq(ev->info, NULL);
+}
+
+EFL_START_TEST (spin_value_events)
+{
+   Eina_Bool changed = EINA_FALSE, min_reached = EINA_FALSE, max_reached = EINA_FALSE;
+
+   efl_ui_range_limits_set(spin, -3.0, 3.0);
+   efl_ui_range_value_set(spin, 0.0);
+   efl_event_callback_add(spin, EFL_UI_SPIN_EVENT_CHANGED, _set_flag, &changed);
+   efl_event_callback_add(spin, EFL_UI_SPIN_EVENT_MIN_REACHED, _set_flag, &min_reached);
+   efl_event_callback_add(spin, EFL_UI_SPIN_EVENT_MAX_REACHED, _set_flag, &max_reached);
+
+   efl_ui_range_value_set(spin, 1.0);
+   ck_assert_int_eq(changed, EINA_TRUE);
+   ck_assert_int_eq(min_reached, EINA_FALSE);
+   ck_assert_int_eq(max_reached, EINA_FALSE);
+   changed = EINA_FALSE;
+   min_reached = EINA_FALSE;
+   max_reached = EINA_FALSE;
+
+   efl_ui_range_value_set(spin, 3.0);
+   ck_assert_int_eq(changed, EINA_TRUE);
+   ck_assert_int_eq(min_reached, EINA_FALSE);
+   ck_assert_int_eq(max_reached, EINA_TRUE);
+   changed = EINA_FALSE;
+   min_reached = EINA_FALSE;
+   max_reached = EINA_FALSE;
+
+   efl_ui_range_value_set(spin, -3.0);
+   ck_assert_int_eq(changed, EINA_TRUE);
+   ck_assert_int_eq(min_reached, EINA_TRUE);
+   ck_assert_int_eq(max_reached, EINA_FALSE);
+   changed = EINA_FALSE;
+   min_reached = EINA_FALSE;
+   max_reached = EINA_FALSE;
+}
+EFL_END_TEST
+
+EFL_START_TEST (spin_wheel_test)
+{
+   efl_ui_range_limits_set(spin, -100.0, 100.0);
+   efl_ui_range_value_set(spin, 0.0);
+   efl_ui_range_step_set(spin, 10.0);
+   efl_gfx_entity_size_set(win, EINA_SIZE2D(60, 60));
+   get_me_to_those_events(spin);
+   evas_event_feed_mouse_move(evas_object_evas_get(spin), 30, 30, 1234, NULL);
+   ck_assert(efl_ui_range_value_get(spin) == 0.0);
+   evas_event_feed_mouse_wheel(evas_object_evas_get(spin), -1, -1, 12345, NULL);
+   ck_assert(efl_ui_range_value_get(spin) == 10.0);
+   evas_event_feed_mouse_wheel(evas_object_evas_get(spin), -1, 1, 12345, NULL);
+   ck_assert(efl_ui_range_value_get(spin) == 0.0);
+}
+EFL_END_TEST
+
+void efl_ui_test_spin(TCase *tc)
+{
+   tcase_add_checked_fixture(tc, fail_on_errors_setup, fail_on_errors_teardown);
+   tcase_add_checked_fixture(tc, spin_setup, NULL);
+   tcase_add_test(tc, spin_value_events);
+   tcase_add_test(tc, spin_wheel_test);
+}

--- a/src/tests/elementary/efl_ui_test_spin.c
+++ b/src/tests/elementary/efl_ui_test_spin.c
@@ -21,6 +21,8 @@ _set_flag(void *data, const Efl_Event *ev)
 {
    Eina_Bool *b = data;
 
+   ck_assert_int_eq(*b, EINA_FALSE);
+
    *b = EINA_TRUE;
    ck_assert_ptr_eq(ev->info, NULL);
 }
@@ -63,17 +65,35 @@ EFL_END_TEST
 
 EFL_START_TEST (spin_wheel_test)
 {
+   Eina_Bool changed = EINA_FALSE, min_reached = EINA_FALSE, max_reached = EINA_FALSE;
+
    efl_ui_range_limits_set(spin, -100.0, 100.0);
    efl_ui_range_value_set(spin, 0.0);
    efl_ui_range_step_set(spin, 10.0);
+   efl_event_callback_add(spin, EFL_UI_SPIN_EVENT_CHANGED, _set_flag, &changed);
+   efl_event_callback_add(spin, EFL_UI_SPIN_EVENT_MIN_REACHED, _set_flag, &min_reached);
+   efl_event_callback_add(spin, EFL_UI_SPIN_EVENT_MAX_REACHED, _set_flag, &max_reached);
+
    efl_gfx_entity_size_set(win, EINA_SIZE2D(60, 60));
    get_me_to_those_events(spin);
    evas_event_feed_mouse_move(evas_object_evas_get(spin), 30, 30, 1234, NULL);
-   ck_assert(efl_ui_range_value_get(spin) == 0.0);
    evas_event_feed_mouse_wheel(evas_object_evas_get(spin), -1, -1, 12345, NULL);
    ck_assert(efl_ui_range_value_get(spin) == 10.0);
+   ck_assert_int_eq(changed, EINA_TRUE);
+   ck_assert_int_eq(min_reached, EINA_FALSE);
+   ck_assert_int_eq(max_reached, EINA_FALSE);
+   changed = EINA_FALSE;
+   min_reached = EINA_FALSE;
+   max_reached = EINA_FALSE;
+
    evas_event_feed_mouse_wheel(evas_object_evas_get(spin), -1, 1, 12345, NULL);
    ck_assert(efl_ui_range_value_get(spin) == 0.0);
+   ck_assert_int_eq(changed, EINA_TRUE);
+   ck_assert_int_eq(min_reached, EINA_FALSE);
+   ck_assert_int_eq(max_reached, EINA_FALSE);
+   changed = EINA_FALSE;
+   min_reached = EINA_FALSE;
+   max_reached = EINA_FALSE;
 }
 EFL_END_TEST
 

--- a/src/tests/elementary/meson.build
+++ b/src/tests/elementary/meson.build
@@ -143,6 +143,7 @@ efl_ui_suite_src = [
   'efl_ui_test_check.c',
   'efl_ui_test_radio_group.c',
   'efl_ui_test_progressbar.c',
+  'efl_ui_test_spin.c',
 ]
 
 efl_ui_suite = executable('efl_ui_suite',

--- a/src/tests/elementary/spec/efl_test_range_display.c
+++ b/src/tests/elementary/spec/efl_test_range_display.c
@@ -1,0 +1,90 @@
+#ifdef HAVE_CONFIG_H
+# include "elementary_config.h"
+#endif
+
+#include <Efl_Ui.h>
+#include "efl_ui_spec_suite.h"
+#include "suite_helpers.h"
+
+/* spec-meta-start
+      {"test-interface":"Efl.Ui.Range_Display",
+       "test-widgets": ["Efl.Ui.Spin", "Efl.Ui.Progressbar", "Efl.Ui.Slider", "Efl.Ui.Spin_Button"]}
+   spec-meta-end */
+
+EFL_START_TEST(value_setting_limits)
+{
+   efl_ui_range_limits_set(widget, -20.0, 20.0);
+   efl_ui_range_value_set(widget, 10.0);
+
+   EXPECT_ERROR_START;
+   efl_ui_range_value_set(widget, -25.0);
+   EXPECT_ERROR_END;
+   ck_assert(efl_ui_range_value_get(widget) == 10.0);
+
+   EXPECT_ERROR_START;
+   efl_ui_range_value_set(widget, 25.0);
+   EXPECT_ERROR_END;
+   ck_assert(efl_ui_range_value_get(widget) == 10.0);
+}
+EFL_END_TEST
+
+EFL_START_TEST(limit_setting)
+{
+   double min, max;
+
+   efl_ui_range_limits_set(widget, -20.0, 20.0);
+   efl_ui_range_limits_get(widget, &min, &max);
+   ck_assert(min == -20.0);
+   ck_assert(max == 20.0);
+   EXPECT_ERROR_START;
+   efl_ui_range_limits_set(widget, -20.0, -20.0);
+   EXPECT_ERROR_END;
+   efl_ui_range_limits_get(widget, &min, &max);
+   ck_assert(min == -20.0);
+   ck_assert(max == 20.0);
+
+   EXPECT_ERROR_START;
+   efl_ui_range_limits_set(widget, 2.0, -20.0);
+   EXPECT_ERROR_END;
+   efl_ui_range_limits_get(widget, &min, &max);
+   ck_assert(min == -20.0);
+   ck_assert(max == 20.0);
+
+   EXPECT_ERROR_START;
+   efl_ui_range_limits_set(widget, 25.0, 20.0);
+   EXPECT_ERROR_END;
+   efl_ui_range_limits_get(widget, &min, &max);
+   ck_assert(min == -20.0);
+   ck_assert(max == 20.0);
+
+   efl_ui_range_limits_set(widget, -25.0, -20.0);
+   efl_ui_range_limits_get(widget, &min, &max);
+   ck_assert(min == -25.0);
+   ck_assert(max == -20.0);
+
+   efl_ui_range_limits_set(widget, 20.0, 25.0);
+   efl_ui_range_limits_get(widget, &min, &max);
+   ck_assert(min == 20.0);
+   ck_assert(max == 25.0);
+}
+EFL_END_TEST
+
+EFL_START_TEST(value_setting)
+{
+   double i;
+   efl_ui_range_limits_set(widget, -20.0, 20.0);
+   for (i = -20.0; i <= 20.0; ++i)
+     {
+        efl_ui_range_value_set(widget, i);
+        ck_assert(efl_ui_range_value_get(widget) == i);
+     }
+}
+EFL_END_TEST
+
+void
+efl_ui_range_display_behavior_test(TCase *tc)
+{
+   tcase_add_test(tc, value_setting_limits);
+   tcase_add_test(tc, limit_setting);
+   tcase_add_test(tc, value_setting);
+}

--- a/src/tests/elementary/spec/efl_test_range_interactive.c
+++ b/src/tests/elementary/spec/efl_test_range_interactive.c
@@ -1,0 +1,38 @@
+#ifdef HAVE_CONFIG_H
+# include "elementary_config.h"
+#endif
+
+#include <Efl_Ui.h>
+#include "efl_ui_spec_suite.h"
+#include "suite_helpers.h"
+
+/* spec-meta-start
+      {"test-interface":"Efl.Ui.Range_Display_Interactive",
+       "test-widgets": ["Efl.Ui.Spin", "Efl.Ui.Slider", "Efl.Ui.Spin_Button"]}
+   spec-meta-end */
+
+EFL_START_TEST(step_setting)
+{
+   efl_ui_range_step_set(widget, 20.0);
+   ck_assert(efl_ui_range_step_get(widget) == 20.0);
+   efl_ui_range_step_set(widget, 100.0);
+   ck_assert(efl_ui_range_step_get(widget) == 100.0);
+
+   EXPECT_ERROR_START;
+   efl_ui_range_step_set(widget, 0.0);
+   ck_assert(efl_ui_range_step_get(widget) == 100.0);
+   EXPECT_ERROR_END;
+
+   EXPECT_ERROR_START;
+   efl_ui_range_step_set(widget, -20.0);
+   ck_assert(efl_ui_range_step_get(widget) == 100.0);
+   EXPECT_ERROR_END;
+}
+EFL_END_TEST
+
+void
+efl_ui_range_display_interactive_behavior_test(TCase *tc)
+{
+   tcase_add_test(tc, step_setting);
+}
+

--- a/src/tests/elementary/spec/efl_ui_spec_suite.h
+++ b/src/tests/elementary/spec/efl_ui_spec_suite.h
@@ -17,6 +17,7 @@ void efl_gfx_arrangement_behavior_test(TCase *tc);
 void efl_ui_clickable_behavior_test(TCase *tc);
 void efl_ui_format_behavior_test(TCase *tc);
 void efl_ui_range_display_behavior_test(TCase *tc);
+void efl_ui_range_display_interactive_behavior_test(TCase *tc);
 
 void efl_test_container_content_equal(Efl_Ui_Widget **wid, unsigned int len);
 void efl_test_container_expect_evt_content_added(Efl_Ui_Widget *widget, const Efl_Event_Description *ev, Eina_Bool *flag, void *event_data);

--- a/src/tests/elementary/spec/efl_ui_spec_suite.h
+++ b/src/tests/elementary/spec/efl_ui_spec_suite.h
@@ -16,6 +16,7 @@ void efl_content_behavior_test(TCase *tc);
 void efl_gfx_arrangement_behavior_test(TCase *tc);
 void efl_ui_clickable_behavior_test(TCase *tc);
 void efl_ui_format_behavior_test(TCase *tc);
+void efl_ui_range_display_behavior_test(TCase *tc);
 
 void efl_test_container_content_equal(Efl_Ui_Widget **wid, unsigned int len);
 void efl_test_container_expect_evt_content_added(Efl_Ui_Widget *widget, const Efl_Event_Description *ev, Eina_Bool *flag, void *event_data);

--- a/src/tests/elementary/spec/meson.build
+++ b/src/tests/elementary/spec/meson.build
@@ -7,6 +7,7 @@ efl_ui_suite_behavior_test_files = files([
   'efl_test_clickable.c',
   'efl_test_format.c',
   'efl_test_range_display.c',
+  'efl_test_range_interactive.c',
 ])
 
 efl_ui_suite_behavior_src = files([

--- a/src/tests/elementary/spec/meson.build
+++ b/src/tests/elementary/spec/meson.build
@@ -6,6 +6,7 @@ efl_ui_suite_behavior_test_files = files([
   'efl_test_gfx_arrangement.c',
   'efl_test_clickable.c',
   'efl_test_format.c',
+  'efl_test_range_display.c',
 ])
 
 efl_ui_suite_behavior_src = files([


### PR DESCRIPTION
This also adds tests and fixes to simular classes or inheriting classes. This brings efl_ui_spin closer to beeing stable.